### PR TITLE
Inline converter doesn't split on whitespace.

### DIFF
--- a/formd
+++ b/formd
@@ -61,7 +61,7 @@ class ForMd(object):
         """ created referenced or inline markdown """
         self._format()
         if inline is True:
-            text_link = iter([''.join((_[0].split("][",1)[0], "](", _[1].split(":",1)[1].strip().split()[0], ")")) for _ in self.data])
+            text_link = iter([''.join((_[0].split("][",1)[0], "](", _[1].split(":",1)[1].strip(), ")")) for _ in self.data])
             formd_text = self.match_links.sub(lambda _: next(text_link), md)
             formd_md = self.match_refs.sub('', formd_text).strip()
         else:


### PR DESCRIPTION
When converting to inline links, splitting on whitespace prevents using things like template variables in your links.

e.g.

```
[1]: {{ site.photos }}/hello.jpg
```

would become

```
![description]({{)
```

I don't know how common this is, and it doesn't seem to go against the markdown spec (it's also accepted by maruku, kramdown, and rdiscount FWIW), but it's something I use with Jekyll.
