### PR TITLE
Improved handling of MMD footnotes in edge cases

### DIFF
--- a/formd
+++ b/formd
@@ -14,9 +14,9 @@ class ForMd(object):
     def __init__(self, text):
         super(ForMd, self).__init__()
         self.text = text
-        self.match_links = re.compile(r'(\[.*?\])\s?(\[.*?\]|\(.*?\))',
+        self.match_links = re.compile(r'(\[[^^]*?\])\s?(\[.*?\]|\(.*?\))',
                 re.DOTALL | re.MULTILINE)
-        self.match_refs = re.compile(r'(?<=\n)\[[^^].*?\]:\s?.*')
+        self.match_refs = re.compile(r'(?<=\n)\[[^^]*?\]:\s?.*')
         self.data = []
 
     def _links(self, ):


### PR DESCRIPTION
Changed link parsing RE to not treat the span from a trailing 
footnote number to the first footnote as a Markdown link (which
would result in formd stripping the paragraph break before the
first footnote, effectively invalidating that footnote).
