### PR TITLE
properly use relative import

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
-from formd import ForMd
+from .formd import ForMd
 
 __version__ = '1.0.0'
 __all__ = ['ForMd']


### PR DESCRIPTION
This prevents raising a ModuleNotFoundError error when attempting to use
formd with Python 3, and also works with Python 2.